### PR TITLE
Removed default argument of pat9125_set_res() in pat1925.cpp.

### DIFF
--- a/pat9125.cpp
+++ b/pat9125.cpp
@@ -33,7 +33,7 @@ bool PAT9125::pat9125_read_pid(){
   else return false; 
 }
 
-void PAT9125::pat9125_set_res(uint8_t xres, uint8_t yres, bool bitres12 = false) {
+void PAT9125::pat9125_set_res(uint8_t xres, uint8_t yres, bool bitres12) {
   if (bitres12) write_reg(PAT9125_ORIENTATION, 0x04);//12bit resolution
   write_reg(PAT9125_RES_X, xres);
   write_reg(PAT9125_RES_Y, yres);


### PR DESCRIPTION
Removed default argument of `pat9125_set_res()` in pat1925.cpp. This allows the code to be compiled for ESP32 boards.